### PR TITLE
Use topology information to find hydrogens in water

### DIFF
--- a/WaterNetworkAnalysis/WaterNetworkAnalysis.py
+++ b/WaterNetworkAnalysis/WaterNetworkAnalysis.py
@@ -360,6 +360,9 @@ def extract_waters_from_trajectory(
         u = mda.Universe(trajectory)
     coordsH = []
     coordsO = []
+    waters = u.select_atoms(f'resname {SOL}')
+    if len(waters.bonds) == 0:
+        waters.guess_bonds()
     # loop over
     for nn, k in enumerate(u.trajectory):
         Os = u.select_atoms(
@@ -376,23 +379,12 @@ def extract_waters_from_trajectory(
             + " "
             + str(dist)
         )
-        for i, j in zip(Os.positions, Os.indices):
-            Hs = u.select_atoms(
-                "(name "
-                + str(HW1)
-                + " or name "
-                + str(HW2)
-                + ") and around 1.0 index "
-                + str(j)
-            )
+        for i, j in zip(Os.positions, Os):
+            Hs = j.bonded_atoms
             if len(Hs) != 2:
-                # raise Exception(
-                #    f"Water {j} in snapshot {i} has too many hydrogens ({len(Hs)})."
-                # )
-                print(
-                    f"Water {j} in snapshot {i} has too many hydrogens ({len(Hs)}). Skipping."
+                raise Exception(
+                   f"Water {j} in snapshot {i} has too many hydrogens ({len(Hs)})."
                 )
-                continue
             for l in Hs.positions:
                 coordsH.append(l)
             coordsO.append(i)

--- a/WaterNetworkAnalysis/WaterNetworkAnalysis.py
+++ b/WaterNetworkAnalysis/WaterNetworkAnalysis.py
@@ -311,8 +311,6 @@ def extract_waters_from_trajectory(
     dist: float = 12.0,
     SOL: str = "SOL",
     OW: str = "OW",
-    HW1: str = "HW1",
-    HW2: str = "HW2",
     save_file: str | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Extract waters for clustering analysis.
@@ -331,10 +329,6 @@ def extract_waters_from_trajectory(
         SOL (str, optional): Residue name for waters. Defaults to "SOL".
         OW (str, optional): Name of the oxygen atom in water molecules.
             Defaults to "OW".
-        HW1 (str, optional): Name of hydrogen 1 atom in water molecules.
-            Defaults to "HW1".
-        HW2 (str, optional): Name of hydrogen 2 atom in water molecules.
-            Defaults to "HW2".
         save_file (str | None, optional): File to which coordinates will
             be saved. If none doesn't save to a file. Defaults to None.
 
@@ -353,7 +347,6 @@ def extract_waters_from_trajectory(
             topology = 'topology.tpr'
         )
     """
-    # think about another method of selecting waters - ie within some distance of an atom index?
     if topology:
         u = mda.Universe(topology, trajectory)
     else:


### PR DESCRIPTION
This pull request addresses #17 with the bonding detection mechanism for water molecules in our MDAnalysis Universe objects.

Previously, we relied on a fixed distance measure to determine which hydrogens were bonded to the oxygen in water molecules. However, this method was prone to errors due to inconsistencies in the distance units between GROMACS (which uses nanometers) and psf/dcd files (which use Angstroms). This discrepancy could lead to incorrect identification of bonded atoms and generate warning/error messages indicating that a water molecule has too many hydrogens.

To resolve this issue, I've made the following changes:

1. Upon creation of the Universe object, the code now checks if bonding information exists for the water molecules. If not, it calls the `guess_bonds()` method to generate this information.

2. When identifying the hydrogens bonded to each oxygen atom, the code now uses the `bonded_atoms` attribute instead of a distance-based selection. This method is less prone to errors caused by unit discrepancies.

3. The code now raises an Exception if a water molecule is found to have more than two hydrogens. This should help us to quickly identify and address any potential issues with the bonding information.

These changes improve the robustness of our molecule bonding detection mechanism and should help to prevent future errors related to unit discrepancies or missing bonding information.
