### PR TITLE
Support reading (pdb) files with different atom numbers in trajectory

### DIFF
--- a/tests/test_WaterNetworkAnalysis.py
+++ b/tests/test_WaterNetworkAnalysis.py
@@ -109,6 +109,17 @@ def test_extract_waters_from_trajectory():
     # os.remove("tests/data/testalignedtrj.xtc_offsets.lock")
 
 
+def test_extract_waters_from_trajectory_pdb_uneq_num_of_atoms():
+    altrj = "tests/data/test_noneq_atom_num.pdb"
+    extract_waters_from_trajectory(
+        get_center_of_selection(
+            "resname UBX",
+            altrj,
+        ),
+        altrj,
+    )
+
+
 def test_align_mda():
     align_trajectory(
         trajectory="tests/data/testtrjgromacs.xtc",


### PR DESCRIPTION
This PR introduces capability of reading pdb files which have inconsistent number of atoms in different frames. MDAnalysis is uncapable of handling this, and many file formats don't allow for it, but it is relatively frequent especially when dealing with pdb files.